### PR TITLE
Update .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -14,7 +14,7 @@
 	"quotmark":"single", 
 	"undef":true,
 	"unused":true,
-	"strict":true,
+	"strict":false,
 	"trailing":true, 
 	"smarttabs":true, 
 	"jquery":true,


### PR DESCRIPTION
Prueba a quitar el "use strict" como obligatorio cuando se ejecuta la tarea de jshint. ya que el templates.js, a generarse solo no incluye el use strict y es posible que falle por eso.